### PR TITLE
fix(build): add slash for image reference to assets directory

### DIFF
--- a/components/Steps.vue
+++ b/components/Steps.vue
@@ -49,7 +49,7 @@
         
         <!-- MacBook-Illustration -->
         <div class="mb-4 flex justify-center || 2xl:mb-20">
-            <img class="w-80 || sm: w-[35rem] || md:[42rem] || lg:w-[50rem] || xl:w-[55rem]" src="assets/img/macbookpro.png" alt="illustartion-macbook">
+            <img class="w-80 || sm: w-[35rem] || md:[42rem] || lg:w-[50rem] || xl:w-[55rem]" src="/assets/img/macbookpro.png" alt="illustartion-macbook">
         </div>
     </div>
  </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
         </div>
         
         
-        <img class="z-0 absolute bottom-0" src="assets/img/wave.svg" alt="wave-illustration">
+        <img class="z-0 absolute bottom-0" src="/assets/img/wave.svg" alt="wave-illustration">
         
     </div>
 </template>


### PR DESCRIPTION
We need to add a slash when loading a image from the assets directory.

Closes #9 