### PR TITLE
chore: add release-please bot to workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action


### PR DESCRIPTION
This commit adds the [release-please bot](https://github.com/googleapis/release-please) from Google as a chore to the project's workflows. The release-please bot automates the release process and facilitates the generation of release notes, changelogs, and GitHub releases.

The release-please bot is integrated into the project's workflows and performs the following tasks:
- Automatically detects tagged commits and triggers the release process.
- Extracts relevant information from the commit messages to generate release notes.
- Creates a comprehensive changelog summarizing the changes between the previous release and the current one.
- Automatically generates a GitHub release, including the tag name and the generated changelog.
- Notifies team members about the new release and its details.

By incorporating the release-please bot into our workflows as a chore, we can streamline the release process, improve efficiency, and enhance collaboration among team members. This automation reduces manual effort, ensures consistent release documentation, and enhances the visibility of project updates.