### PR TITLE
fix(Preset): increase course preset limit to 100

### DIFF
--- a/components/AccountPage.vue
+++ b/components/AccountPage.vue
@@ -291,7 +291,7 @@ export default {
       const PRE_COURSES_DATA = await APP_DATABASE.listDocuments(
         "uni_data",
         "course_data",
-        [Query.equal("major_id", data.selectedMajor.$id)]
+        [Query.limit(100), Query.equal("major_id", data.selectedMajor.$id)]
       );
       try {
         const USER = await APP_ACCOUNT.get();

--- a/components/Identification.vue
+++ b/components/Identification.vue
@@ -253,7 +253,7 @@ export default {
       const PRE_COURSES_DATA = await APP_DATABASE.listDocuments(
         "uni_data",
         "course_data",
-        [Query.equal("major_id", data.majorInput.$id)]
+        [Query.limit(100), Query.equal("major_id", data.majorInput.$id)]
       );
 
       try {


### PR DESCRIPTION
Increase the course preset limit from 25 to 100 to ensure that all courses are loaded correctly on the introduction and account page in the SmartsGrades app.