### PR TITLE
chore: Add macOS to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,8 @@ dist
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,30 @@ dist
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
This commit addresses a maintenance task related to the SmartsGrades app. The .gitignore file has been updated to include macOS-specific files, ensuring they are excluded from version control.

By adding macOS to the .gitignore file, we prevent irrelevant files from being tracked and committed, maintaining a clean and efficient repository.

This commit improves the project's organization and contributes to a streamlined development process.