### PR TITLE
feat: Add app logo as home button and include pointers and dividers for list items

### DIFF
--- a/components/Identification.vue
+++ b/components/Identification.vue
@@ -2,20 +2,7 @@
   <div>
     <div class="mb-6 flex justify-center">
       <NuxtLink to="/">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="w-12 h-12 text-white hover:scale-110 cursor-pointer duration-300 ease-out-in"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5"
-          />
-        </svg>
+        <img src="/assets/img/logo.png" class="w-20 h-20 hover:scale-110 duration-300 ease-out-in cursor-pointer" alt="SmartGrades-Logo">
       </NuxtLink>
     </div>
 
@@ -54,12 +41,13 @@
           <!-- SEARCH LIST UNI -->
           <ul
             v-if="filteredUnis.length > 0"
-            class="mt-2 block w-full py-3 border border-gray-600 rounded-lg px-4 bg-transparent text-gray-300"
+            class="mt-2 block w-full py-3 border border-gray-600 rounded-lg px-4 bg-transparent text-gray-300 cursor-pointer"
           >
             <li
               v-for="option in filteredUnis"
               :key="option.$id"
               @click="selectUni(option)"
+              class="last:border-b-0 border-b border-gray-400 py-2"
             >
               {{ option.name }}
             </li>
@@ -91,12 +79,13 @@
           <ul
             v-if="filteredMajor.length > 0"
             id="myMajorList"
-            class="mt-2 w-full py-3 border border-gray-600 rounded-lg px-4 bg-transparent text-gray-300"
+            class="mt-2 w-full py-3 border border-gray-600 rounded-lg px-4 bg-transparent text-gray-300 cursor-pointer"
           >
             <li
               v-for="option in filteredMajor"
               :key="option.$id"
               @click="selectMajor(option)"
+              class="last:border-b-0 border-b border-gray-400 py-2"
             >
               {{ option.name }}
             </li>


### PR DESCRIPTION
This commit introduces significant visual improvements to the SmartsGrades app. The app logo has been added as the home button, providing users with a distinct and recognizable navigation element that enhances brand identity. Additionally, pointers and dividers have been implemented for list items, improving visual organization and clarity within the app.

By adding the app logo as the home button and including pointers and dividers for list items, this commit enhances the overall user experience and aesthetics of the SmartsGrades app. Users will benefit from a more intuitive and visually appealing interface, with improved navigation and enhanced readability for list-based content.

Closes #59 